### PR TITLE
MauiCameraView: wait for the camera to close before disposing and cleanup Android 15

### DIFF
--- a/Camera.MAUI/Platforms/Android/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Android/MauiCameraView.cs
@@ -385,7 +385,6 @@ internal class MauiCameraView : GridLayout
 
                 mediaRecorder?.Stop();
                 previewSession?.StopRepeating();
-                previewSession?.AbortCaptures();
                 cameraDevice?.Close();
 
                 void CleanUp(object sender, EventArgs args)
@@ -414,6 +413,7 @@ internal class MauiCameraView : GridLayout
                     }
                 }
             }
+            catch { }
         }
         else
             result = CameraResult.NotInitiated;


### PR DESCRIPTION
The control crashes on Android 15 after taking a picture. As requested, this pull request contains the proposed fix as mentioned in this issue: #47