### PR TITLE
Camera.MAUI.Test: demonstrate EAN_13 detection

### DIFF
--- a/Camera.MAUI.Test/MVVM/CameraViewModel.cs
+++ b/Camera.MAUI.Test/MVVM/CameraViewModel.cs
@@ -134,10 +134,10 @@ public class CameraViewModel : INotifyPropertyChanged
     }
     public CameraViewModel()
     {
-        BarCodeOptions = new ZXingHelper.BarcodeDecodeOptions
+        BarCodeOptions = new BarcodeDecodeOptions
         {
             AutoRotate = true,
-            PossibleFormats = { ZXing.BarcodeFormat.QR_CODE },
+            PossibleFormats = { BarcodeFormat.EAN_13, BarcodeFormat.QR_CODE },
             ReadMultipleCodes = false,
             TryHarder = true,
             TryInverted = true

--- a/Camera.MAUI.Test/MVVM/MVVMPage.xaml
+++ b/Camera.MAUI.Test/MVVM/MVVMPage.xaml
@@ -32,7 +32,7 @@
                     <CheckBox BindingContext="{x:Reference cameraView}" x:DataType="cv:CameraView" VerticalOptions="Center" Color="Black" IsChecked="{Binding MirroredImage}"/>
                     <Label Text="Torch" VerticalOptions="Center" TextColor="Black"/>
                     <CheckBox BindingContext="{x:Reference cameraView}" x:DataType="cv:CameraView" VerticalOptions="Center" Color="Black" IsChecked="{Binding TorchEnabled}"/>
-                    <Label Text="QR Detec." VerticalOptions="Center" TextColor="Black"/>
+                    <Label Text="Barcode Detection" VerticalOptions="Center" TextColor="Black"/>
                     <CheckBox BindingContext="{x:Reference cameraView}" x:DataType="cv:CameraView" VerticalOptions="Center" Color="Black" IsChecked="{Binding BarCodeDetectionEnabled}"/>
                 </HorizontalStackLayout>
                 <HorizontalStackLayout HorizontalOptions="Center">

--- a/Camera.MAUI.Test/SizedPage.xaml
+++ b/Camera.MAUI.Test/SizedPage.xaml
@@ -26,7 +26,7 @@
                     <CheckBox CheckedChanged="CheckBox_CheckedChanged" VerticalOptions="Center" Color="Black"/>
                     <Label x:Name="torchLabel" Text="Torch" VerticalOptions="Center" TextColor="Black"/>
                     <CheckBox x:Name="torchCheck" CheckedChanged="CheckBox4_CheckedChanged" VerticalOptions="Center" Color="Black"/>
-                    <Label Text="QR Detec." VerticalOptions="Center" TextColor="Black"/>
+                    <Label Text="Barcode Detection" VerticalOptions="Center" TextColor="Black"/>
                     <CheckBox CheckedChanged="CheckBox3_CheckedChanged" VerticalOptions="Center" Color="Black"/>
                 </HorizontalStackLayout>
                 <HorizontalStackLayout HorizontalOptions="Center">

--- a/Camera.MAUI.Test/SizedPage.xaml.cs
+++ b/Camera.MAUI.Test/SizedPage.xaml.cs
@@ -33,7 +33,7 @@ public partial class SizedPage : ContentPage
         cameraView.BarCodeOptions = new ZXingHelper.BarcodeDecodeOptions
         {
             AutoRotate = true,
-            PossibleFormats = { BarcodeFormat.EAN_13 },
+            PossibleFormats = { BarcodeFormat.EAN_13, BarcodeFormat.QR_CODE },
             ReadMultipleCodes = false,
             TryHarder = false,
             TryInverted = true


### PR DESCRIPTION
This PR extends the Camera.MAUI.Test app such that EAN_13 codes can be detected on both pages (MVVM and Parameters Cam), provided that the checkbox "Barcode Detection" is enabled. It relates to issue #27.