### PR TITLE
Camera.MAUI.Test: update CommunityToolkit.Maui.MediaElement

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 9.0.205
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
@@ -49,7 +49,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 9.0.205
     - name: Setup XCode
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -74,7 +74,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 9.0.205
     - name: Restore workloads & dependencies
       run: |
         dotnet workload restore

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -35,10 +35,6 @@
 	  <ProvisioningType>manual</ProvisioningType>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="$(TargetFramework.Contains('-ios')) and $(Configuration)=='Debug'">
-	  <MtouchLink>SdkOnly</MtouchLink>
-	</PropertyGroup>
-
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
 	    <RuntimeIdentifiers>maccatalyst-arm64;maccatalyst-x64</RuntimeIdentifiers>
 	</PropertyGroup>
@@ -74,7 +70,7 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />
-		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="4.1.0" />
+		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
 	</ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.205",
+    "workloadsVersion": "9.0.205",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
This is my second attempt to fix issue #51 (after PR #53 failed).

As in the previous attempt, I'm upgrading the MediaElement package, but only to 5.0.0 this time (6.1.x had build problems on Windows in #53, and with 6.0.x the sample app fails with an AbstractMethodError on Android). This only works together with a fix for https://github.com/CommunityToolkit/Maui/issues/2850 (concerning iOS).

This package update as such does not fix #51, so I'm limiting the .NET SDK to 9.0.20x in addition.