### PR TITLE
Fix crash when disposing CameraView on Android 15+

### DIFF
--- a/Camera.MAUI/Platforms/Android/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Android/MauiCameraView.cs
@@ -423,8 +423,6 @@ internal class MauiCameraView : GridLayout
         try
         {
             if (started) StopCamera();
-            executorService?.Shutdown();
-            executorService?.Dispose();
             RemoveAllViews();
             textureView?.Dispose();
             timer?.Dispose();
@@ -920,6 +918,12 @@ internal class MauiCameraView : GridLayout
                 cameraView.cameraDevice = camera;
                 cameraView.StartPreview();
             }
+        }
+
+        public override void OnClosed(CameraDevice camera)
+        {
+            cameraView.executorService?.Shutdown();
+            cameraView.executorService?.Dispose();
         }
 
         public override void OnDisconnected(CameraDevice camera)


### PR DESCRIPTION
... by making sure that the executor service is only shut down after the camera has been closed.

This is supposed to fix issue #47, and is an alternative solution to PR #48, which did not work properly for me.

Contrary to the analysis at https://github.com/janusw/CameraMaui/issues/47#issue-3223104503, it seems to me the problem is not actually caused by the `backgroundThread` being stopped too soon (which is basically just used for callback when a new photo is available), but instead by the `executorService` being shut down too early.

After making sure that the `executorService` is only shut down after the camera has been properly closed, the reproduction procedure (as described in https://github.com/janusw/CameraMaui/issues/47#issuecomment-3064940346) does not trigger a crash any more in my tests.

@Leonardo-pixel @Raifex Could you guys please check if this PR fixes the problem as you observe it? (If it does not, there is still the possibility that there are two separate problems that require different fixes. But since the error message and backtrace seem to be completely identical, I hope it is actually one single problem and both scenarios are fixed by my patch here ...)