### PR TITLE
Video rotation tracks device orientation

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,10 +4,10 @@
 name: .NET
 
 on:
-  push:
-    branches: [ "**" ]
-  pull_request:
-    branches: [ "**" ]
+  #push:
+  #  branches: [ "**" ]
+  #pull_request:
+  #  branches: [ "**" ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -22,23 +22,26 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.205
+        dotnet-version: 9.0.200
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'
-    - name: Restore dependencies
-      run: dotnet restore
+    - name: Restore workloads & dependencies
+      shell: pwsh
+      run: |
+        #dotnet workload restore Camera.MAUI.Test/Camera.MAUI.Test.csproj --version 9.0.200
+        dotnet restore Camera.MAUI.Test/Camera.MAUI.Test.csproj
     - name: Build Lib
-      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=0.0.1
     - name: Upload package
       uses: actions/upload-artifact@v4
       with:
         name: nupkg
         path: ./Camera.MAUI/bin/Release/*.nupkg
     - name: Build Test
-      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj -c Release -p:Version=0.0.1
 
   macBuild:
     runs-on: macos-15
@@ -49,21 +52,22 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.205
+        dotnet-version: 9.0.200
     - name: Setup XCode
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
     - name: Restore workloads & dependencies
+      shell: pwsh
       run: |
-        dotnet workload restore
-        dotnet restore
+        #dotnet workload restore Camera.MAUI.Test/Camera.MAUI.Test.csproj --version 9.0.200
+        dotnet restore Camera.MAUI.Test/Camera.MAUI.Test.csproj
     - name: Install Android tools
       run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platforms;android-34" "build-tools;34.0.0" "platform-tools"
     - name: Build Lib
-      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=0.0.1
     - name: Build Test
-      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release -p:Version=0.0.1
 
   linuxBuild:
     runs-on: ubuntu-latest
@@ -74,14 +78,15 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.205
+        dotnet-version: 9.0.200
     - name: Restore workloads & dependencies
+      shell: pwsh
       run: |
-        dotnet workload restore
-        dotnet restore
+        #dotnet workload restore Camera.MAUI.Test/Camera.MAUI.Test.csproj --version 9.0.200
+        dotnet restore Camera.MAUI.Test/Camera.MAUI.Test.csproj
     - name: Install Android tools
       run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platform-tools"
     - name: Build Lib
-      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=0.0.1
     - name: Build Test
-      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release -p:Version=0.0.1

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -69,6 +69,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -29,7 +29,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -9,6 +9,8 @@
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Camera.MAUI.Test</RootNamespace>
 		<UseMaui>true</UseMaui>
+    <!--minimum version compatibale with Toolkit packages-->
+    <MauiVersion>9.0.50</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -95,4 +95,18 @@
 	  </MauiXaml>
 	</ItemGroup>
 
+
+  <!-- Make sure any old temp files are removed-->
+  <Target Name="CustomDroidClean" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <Message Text="Running custom clean up bin... $(ProjectDir)bin" />
+    <Exec Command="rmdir /s /q $(ProjectDir)bin" />
+    <Message Text="Running custom clean up obj... $(ProjectDir)obj" />
+    <Exec Command="rmdir /s /q $(ProjectDir)obj" />
+  </Target>
+  <Target Name="CustomDroidCleanMac" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <Message Text="Running custom clean up bin... $(ProjectDir)bin" />
+    <Exec Command="rm -R $(ProjectDir)bin" ContinueOnError="true" />
+    <Message Text="Running custom clean up obj... $(ProjectDir)obj" />
+    <Exec Command="rm -R $(ProjectDir)obj" ContinueOnError="true" />
+  </Target>
 </Project>

--- a/Camera.MAUI.Test/MVVM/MVVMPage.xaml
+++ b/Camera.MAUI.Test/MVVM/MVVMPage.xaml
@@ -59,6 +59,8 @@
                 <Label Text="{Binding BarcodeText}" TextColor="Black" FontAttributes="Bold" HorizontalOptions="Center" />
                 <Image BindingContext="{x:Reference cameraView}" x:DataType="cv:CameraView" Source="{Binding SnapShot}" Aspect="AspectFit" WidthRequest="250" HeightRequest="100" HorizontalOptions="Center" />
                 <toolkit:MediaElement Source="{Binding VideoSource}" ShouldAutoPlay="False" ShouldShowPlaybackControls="True" HeightRequest="300" WidthRequest="200" />
+                <!--so we can save the video file for offload-->
+                <Button Text="Save Video" Command="{Binding SaveVideo}"/>
             </VerticalStackLayout>
         </Grid>
     </ScrollView>

--- a/Camera.MAUI.Test/Platforms/Android/AndroidManifest.xml
+++ b/Camera.MAUI.Test/Platforms/Android/AndroidManifest.xml
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<application android:requestLegacyExternalStorage="true"
+               android:allowBackup="true"
+               android:icon="@mipmap/appicon"
+               android:roundIcon="@mipmap/appicon_round"
+               android:supportsRtl="true">
+  </application>
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/Camera.MAUI.Test/Platforms/Android/MainActivity.cs
+++ b/Camera.MAUI.Test/Platforms/Android/MainActivity.cs
@@ -4,7 +4,10 @@ using Android.OS;
 
 namespace Camera.MAUI.Test
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme",
+        MainLauncher = true,
+        ScreenOrientation = ScreenOrientation.Portrait,
+        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/Camera.MAUI/AppBuilderExtensions.cs
+++ b/Camera.MAUI/AppBuilderExtensions.cs
@@ -8,6 +8,9 @@ public static class AppBuilderExtensions
         {
             h.AddHandler(typeof(CameraView), typeof(CameraViewHandler));
         });
+
+        builder.Services.AddSingleton<CameraService>();
+
         return builder;
     }
 }

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -58,6 +58,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="ZXing.Net" Version="0.16.10" />

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -69,4 +69,17 @@
 	  </MauiXaml>
 	</ItemGroup>
 
+  <!-- Make sure any old temp files are removed-->
+  <Target Name="CustomDroidClean" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <Message Text="Running custom clean up bin... $(ProjectDir)bin" />
+    <Exec Command="rmdir /s /q $(ProjectDir)bin" />
+    <Message Text="Running custom clean up obj... $(ProjectDir)obj" />
+    <Exec Command="rmdir /s /q $(ProjectDir)obj" />
+  </Target>
+  <Target Name="CustomDroidCleanMac" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <Message Text="Running custom clean up bin... $(ProjectDir)bin" />
+    <Exec Command="rm -R $(ProjectDir)bin" ContinueOnError="true" />
+    <Message Text="Running custom clean up obj... $(ProjectDir)obj" />
+    <Exec Command="rm -R $(ProjectDir)obj" ContinueOnError="true" />
+  </Target>
 </Project>

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -7,7 +7,7 @@
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen<</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
-		<SingleProject>true</SingleProject>
+       <SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
@@ -34,6 +34,11 @@
 		<Version>1.4.11</Version>
 	</PropertyGroup>
 
+  <!--allow builds with SDK 9.0.200 workloads < 9.0.200 (some early versions of 9.0.200 SDK package workload v 9.0.100, also some early versions of workload 9.0.200 ref maui packages as old as 9.0.14)-->
+  <!--The actual MINIMUM version compatibale with this lib is probably just Maui8, Maui/.Net9 isn't even needed as a target, possibly?-->
+  <PropertyGroup Condition="$([System.String]::Copy('$(TargetFramework)').Contains('net9'))">
+    <MauiVersion>9.0.21</MauiVersion>
+  </PropertyGroup>
 	<ItemGroup>
 	  <Folder Include="Platforms\iOS\" />
 	  <Folder Include="Platforms\MacCatalyst\" />

--- a/Camera.MAUI/CameraService.cs
+++ b/Camera.MAUI/CameraService.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+//using CommunityToolkit.Mvvm.Input;
+
+using Debug = System.Diagnostics.Debug;
+namespace Camera.MAUI;
+
+public class CameraService : CommunityToolkit.Mvvm.ComponentModel.ObservableObject//, ICameraService 
+{
+    public string RawOrientation
+    {
+        get => _rawOrientation;
+        set => SetProperty(ref _rawOrientation, value);
+    }
+    private string _rawOrientation;
+
+    public System.Numerics.Vector3 Acceleration
+    {
+        get => _acceleration;
+        set => SetProperty(ref _acceleration, value);
+    }
+    private System.Numerics.Vector3 _acceleration;
+
+    public float DeviceOrientationAngle
+    {
+        get => _deviceOrientationAngle;
+        protected set => SetProperty(ref _deviceOrientationAngle, value);
+    }
+    private float _deviceOrientationAngle;
+
+    private float ComputeDeviceOrientation()
+    {
+        float y = Acceleration.Y;
+        float x = Acceleration.X;
+
+        //**todo: Android-specific?
+        //**todo: move this to after we get the update from accelerometer, so that this can be subscribed to?
+        // Correct 0° reference: add 90° so 0° matches the phone's native orientation
+        double angle = Math.Atan2(-x, y) * (180.0 / Math.PI) + 90.0;
+        if (angle < 0) angle += 360;
+        if (angle > 360) angle -= 360;
+
+        return (float)angle;
+    }
+
+    public CameraService() {}
+
+    public void StopAccelerometer()
+    {
+        if (Accelerometer.IsSupported)
+        {
+            Accelerometer.Stop();
+            Accelerometer.ReadingChanged -= OnAccelerometerReadingChanged;
+        }
+    }
+
+    public void StartAccelerometer()
+    {
+        if (!Accelerometer.IsSupported) return;
+        if (Accelerometer.IsMonitoring) return; // already started
+
+        Accelerometer.ReadingChanged += OnAccelerometerReadingChanged;
+        Accelerometer.Start(SensorSpeed.UI);
+    }
+
+    private uint sample = 0;
+
+    private void OnAccelerometerReadingChanged(object sender, AccelerometerChangedEventArgs e)
+    {
+        // this sample rate produces updates ~2Hz
+        if (sample == 10)
+        {
+            sample = 0;
+            return;
+        }
+
+        if (sample == 0)
+        {
+            Acceleration = e.Reading.Acceleration;
+            RawOrientation = e.Reading.Acceleration.ToString();
+            //**todo: calc the new orientation here so that app-code can subscribe to it only when it changes/databind
+            Debug.WriteLine($"Device accel: {RawOrientation}");
+            DeviceOrientationAngle = ComputeDeviceOrientation();
+        }
+
+        ++sample;
+    }
+
+}

--- a/Camera.MAUI/CameraViewHandler.cs
+++ b/Camera.MAUI/CameraViewHandler.cs
@@ -26,7 +26,10 @@ internal partial class CameraViewHandler : ViewHandler<CameraView, PlatformView>
     {
     }
 #if ANDROID
-    protected override PlatformView CreatePlatformView() => new(Context, VirtualView);
+    protected override PlatformView CreatePlatformView() 
+                                    => new(Context,
+                                            VirtualView,
+                                            IPlatformApplication.Current.Services.GetService<CameraService>());
 #elif IOS || MACCATALYST || WINDOWS
     protected override PlatformView CreatePlatformView() => new(VirtualView);
 #else

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
     "version": "9.0.200",
-    "workloadsVersion": "9.0.200",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
@janusw 
This is based on the repro branch: 
https://github.com/jasells/CameraMaui/tree/android-rotation-issue-repro

And fixes this #50: the case where app-code may lock the app-layout to a single orientation, but during video-record, the device's _actual_ orientation can be different, resulting in "sideways" videos. (Images/still-pics will also do this, but not yet addressed in this PR).

This commit is the fix. https://github.com/janusw/CameraMaui/pull/60/commits/69c28033f1c484420fc661adc518b3fb27929804
These commits are the repro setup.
https://github.com/janusw/CameraMaui/pull/60/commits/9bf023b39425f10e40cc0c1c3c7a34ab7970b59a
https://github.com/janusw/CameraMaui/pull/60/commits/83d7abb2822db43d544c3334725f5e87773c3648

The rest are to make the test-app debuggable on my system/ SDK 9.0.200 systems.