### PR TITLE
Use fixed MAUI version and update to .NET SDK 9.0.30x

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.205
+        dotnet-version: 9.0.x
     - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
@@ -49,7 +49,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.205
+        dotnet-version: 9.0.x
     - name: Setup XCode
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -74,7 +74,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.205
+        dotnet-version: 9.0.x
     - name: Restore workloads & dependencies
       run: |
         dotnet workload restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,8 +28,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '11'
-    - name: Restore dependencies
-      run: dotnet restore
+    - name: Restore workloads & dependencies
+      run: |
+        dotnet workload restore
+        dotnet workload list
+        dotnet restore
     - name: Build Lib
       run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=$(git describe --tags)
     - name: Upload package
@@ -57,6 +60,7 @@ jobs:
     - name: Restore workloads & dependencies
       run: |
         dotnet workload restore
+        dotnet workload list
         dotnet restore
     - name: Install Android tools
       run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platforms;android-34" "build-tools;34.0.0" "platform-tools"
@@ -78,6 +82,7 @@ jobs:
     - name: Restore workloads & dependencies
       run: |
         dotnet workload restore
+        dotnet workload list
         dotnet restore
     - name: Install Android tools
       run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platform-tools"

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -9,6 +9,7 @@
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Camera.MAUI.Test</RootNamespace>
 		<UseMaui>true</UseMaui>
+		<MauiVersion>9.0.51</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -34,6 +34,10 @@
 		<Version>1.4.11</Version>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$(TargetFramework.Contains('net9'))">
+		<MauiVersion>9.0.51</MauiVersion>
+	</PropertyGroup>
+
 	<ItemGroup>
 	  <Folder Include="Platforms\iOS\" />
 	  <Folder Include="Platforms\MacCatalyst\" />

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200",
-    "workloadsVersion": "9.0.200",
-    "rollForward": "latestPatch"
+    "version": "9.0.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This PR fixes build and CI problems with recent .NET SDK versions. Firstly it fixes the MAUI version to 9.0.51 for now (which is also what was used for the last release 1.4.11), instead of using the version that is suggested by the SDK by default. This then makes it possible to go beyond SDK 9.0.20x and use the latest version 9.0.30x (currently 304), which was failing previously (see also PR #54).

It also makes the CI builds on the different platforms more consistent (by restoring workloads on Windows), and shows the used workload versions in the logs now.

@jasells Could you please check if this builds well in your environment? (I hope it should work with any 9.x SDK version).