### PR TITLE
Track device rotation (Droid)

### DIFF
--- a/BuildInfo.txt
+++ b/BuildInfo.txt
@@ -1,0 +1,22 @@
+/// ****************************************************************************************
+/// **  The CI-CD Pipeline will use this file to auto-version and track builds/releases.  **
+/// ****************************************************************************************
+
+/// <summary>
+/// Specifies the name of the package to release.
+/// This tag and value is required for tracking in the history.json file.
+/// </summary>
+/// <example>
+/// [Package Name]
+/// My.Package
+/// </example>
+[Package Name]
+XDev.CameraMaui
+
+/// <summary>
+/// Specifies the 3 octet version of the release.  This is the versioning schema used by Nuget.
+/// This tag and value is required.
+/// This should match the native version we're linking to in the .csproj file <AndroidMavenLibrary> node.
+/// </summary>
+[Release Version]
+1.4.13

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -94,4 +94,17 @@
 	  </MauiXaml>
 	</ItemGroup>
 
+  <!-- Make sure any old temp files are removed-->
+  <Target Name="CustomClean" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <Message Text="Running custom clean up... $(ProjectDir)bin" />
+    <Exec Command="rmdir /s /q $(ProjectDir)bin" />
+    <Message Text="Running custom clean up... $(ProjectDir)obj" />
+    <Exec Command="rmdir /s /q $(ProjectDir)obj" />
+  </Target>
+  <Target Name="CustomCleanMac" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <Message Text="Running custom clean up... $(ProjectDir)bin" />
+    <Exec Command="rm -R $(ProjectDir)bin" ContinueOnError="true" />
+    <Message Text="Running custom clean up... $(ProjectDir)obj" />
+    <Exec Command="rm -R $(ProjectDir)obj" ContinueOnError="true" />
+  </Target>
 </Project>

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -68,6 +68,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />

--- a/Camera.MAUI.Test/MVVM/MVVMPage.xaml
+++ b/Camera.MAUI.Test/MVVM/MVVMPage.xaml
@@ -59,6 +59,8 @@
                 <Label Text="{Binding BarcodeText}" TextColor="Black" FontAttributes="Bold" HorizontalOptions="Center" />
                 <Image BindingContext="{x:Reference cameraView}" x:DataType="cv:CameraView" Source="{Binding SnapShot}" Aspect="AspectFit" WidthRequest="250" HeightRequest="100" HorizontalOptions="Center" />
                 <toolkit:MediaElement Source="{Binding VideoSource}" ShouldAutoPlay="False" ShouldShowPlaybackControls="True" HeightRequest="300" WidthRequest="200" />
+                <!--so we can save the video file for offload-->
+                <Button Text="Save Video" Command="{Binding SaveVideo}"/>
             </VerticalStackLayout>
         </Grid>
     </ScrollView>

--- a/Camera.MAUI.Test/Platforms/Android/AndroidManifest.xml
+++ b/Camera.MAUI.Test/Platforms/Android/AndroidManifest.xml
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<application android:requestLegacyExternalStorage="true"
+               android:allowBackup="true"
+               android:icon="@mipmap/appicon"
+               android:roundIcon="@mipmap/appicon_round"
+               android:supportsRtl="true">
+  </application>
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/Camera.MAUI.sln
+++ b/Camera.MAUI.sln
@@ -7,6 +7,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Camera.MAUI", "Camera.MAUI\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Camera.MAUI.Test", "Camera.MAUI.Test\Camera.MAUI.Test.csproj", "{AFE92281-679D-4DC3-AD37-C2BAA6D1C2BD}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		global.json = global.json
+		LICENSE = LICENSE
+		Readme.md = Readme.md
+		BuildInfo.txt = BuildInfo.txt
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Camera.MAUI/AppBuilderExtensions.cs
+++ b/Camera.MAUI/AppBuilderExtensions.cs
@@ -8,6 +8,9 @@ public static class AppBuilderExtensions
         {
             h.AddHandler(typeof(CameraView), typeof(CameraViewHandler));
         });
+
+        builder.Services.AddSingleton<CameraService>();
+
         return builder;
     }
 }

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -33,6 +33,11 @@
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<Version>1.4.12</Version>
 		<Nullable>annotations</Nullable>
+
+    <!--support source-link-->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>
+      $(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb
+    </AllowedOutputExtensionsInPackageBuildOutputFolder>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(TargetFramework.Contains('net9'))">

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -69,4 +69,17 @@
 	  </MauiXaml>
 	</ItemGroup>
 
+  <!-- Make sure any old temp files are removed-->
+  <Target Name="CustomClean" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <Message Text="Running custom clean up... $(ProjectDir)bin" />
+    <Exec Command="rmdir /s /q $(ProjectDir)bin" />
+    <Message Text="Running custom clean up... $(ProjectDir)obj" />
+    <Exec Command="rmdir /s /q $(ProjectDir)obj" />
+  </Target>
+  <Target Name="CustomCleanMac" AfterTargets="Clean" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <Message Text="Running custom clean up... $(ProjectDir)bin" />
+    <Exec Command="rm -R $(ProjectDir)bin" ContinueOnError="true" />
+    <Message Text="Running custom clean up... $(ProjectDir)obj" />
+    <Exec Command="rm -R $(ProjectDir)obj" ContinueOnError="true" />
+  </Target>
 </Project>

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -20,7 +20,12 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Camera and Barcode encode/decode pluging for .NET MAUI Apps</Title>
 		<Description>A Camera View control and a Barcode Endode/Decode control (based on ZXing.Net) for .NET MAUI applications.</Description>
-		<Copyright></Copyright>
+    <PackageReleaseNotes>
+      - testing package CI
+      - added Source Link
+      - Android: fixed issue where video rotation was not correct in some cases 
+    </PackageReleaseNotes>
+    <Copyright></Copyright>
 		<PackageId>XDev.CameraMaui</PackageId>
 		<PackageProjectUrl>https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_git/XDev.Camera.Maui</PackageProjectUrl>
 		<PackageIcon>camera.maui.png</PackageIcon>

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -21,14 +21,14 @@
 		<Title>Camera and Barcode encode/decode pluging for .NET MAUI Apps</Title>
 		<Description>A Camera View control and a Barcode Endode/Decode control (based on ZXing.Net) for .NET MAUI applications.</Description>
 		<Copyright></Copyright>
-		<PackageId>CameraMaui</PackageId>
-		<PackageProjectUrl>https://github.com/janusw/Camera.Maui</PackageProjectUrl>
+		<PackageId>XDev.CameraMaui</PackageId>
+		<PackageProjectUrl>https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_git/XDev.Camera.Maui</PackageProjectUrl>
 		<PackageIcon>camera.maui.png</PackageIcon>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
-		<RepositoryUrl>https://github.com/janusw/Camera.Maui</RepositoryUrl>
+		<RepositoryUrl>https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_git/XDev.Camera.Maui</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>csharp; dotnet; cross-platform; camera; cameraview; codebar; qr; qr-decoder; codebar-encoder; codebar-decoder; camera-component; camera-view;  plugin; maui; dotnet-maui;</PackageTags>
-		<Authors>hjam40</Authors>
+		<Authors>hjam40, Janus Weil, jasells</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<Version>1.4.12</Version>

--- a/Camera.MAUI/CameraService.cs
+++ b/Camera.MAUI/CameraService.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+
+using Debug = System.Diagnostics.Debug;
+namespace Camera.MAUI;
+
+public class CameraService : Internals.ObservableBase
+{
+    public string RawOrientation
+    {
+        get => _rawOrientation;
+        set => SetProperty(ref _rawOrientation, value);
+    }
+    private string _rawOrientation;
+
+    public System.Numerics.Vector3 Acceleration
+    {
+        get => _acceleration;
+        set => SetProperty(ref _acceleration, value);
+    }
+    private System.Numerics.Vector3 _acceleration;
+
+    public float DeviceOrientationAngle
+    {
+        get => _deviceOrientationAngle;
+        protected set => SetProperty(ref _deviceOrientationAngle, value);
+    }
+    private float _deviceOrientationAngle;
+
+    private float ComputeDeviceOrientation()
+    {
+        float y = Acceleration.Y;
+        float x = Acceleration.X;
+
+        //**todo: Android-specific here, so we should... do what?
+        // Correct 0° reference: add 90° so 0° matches the phone's native orientation
+        double angle = Math.Atan2(-x, y) * (180.0 / Math.PI) + 90.0;
+        if (angle < 0) angle += 360;
+        if (angle > 360) angle -= 360;
+
+        return (float)angle;
+    }
+
+    public CameraService() {}
+
+    public void StopAccelerometer()
+    {
+        if (Accelerometer.IsSupported)
+        {
+            Accelerometer.Stop();
+            Accelerometer.ReadingChanged -= OnAccelerometerReadingChanged;
+        }
+    }
+
+    public void StartAccelerometer()
+    {
+        if (!Accelerometer.IsSupported) return;
+        if (Accelerometer.IsMonitoring) return; // already started
+
+        Accelerometer.ReadingChanged += OnAccelerometerReadingChanged;
+        Accelerometer.Start(SensorSpeed.UI);
+    }
+
+    private uint sample = 0;
+
+    private void OnAccelerometerReadingChanged(object sender, AccelerometerChangedEventArgs e)
+    {
+        // this sample rate produces updates ~2Hz
+        if (sample == 10)
+        {
+            sample = 0;
+            return;
+        }
+
+        if (sample == 0)
+        {
+            Acceleration = e.Reading.Acceleration;
+            RawOrientation = e.Reading.Acceleration.ToString();
+            Debug.WriteLine($"Device accel: {RawOrientation}");
+            //calc the new orientation here so that app-code can subscribe to it only when it changes/databind
+            DeviceOrientationAngle = ComputeDeviceOrientation();
+        }
+
+        ++sample;
+    }
+
+}

--- a/Camera.MAUI/CameraViewHandler.cs
+++ b/Camera.MAUI/CameraViewHandler.cs
@@ -26,7 +26,10 @@ internal partial class CameraViewHandler : ViewHandler<CameraView, PlatformView>
     {
     }
 #if ANDROID
-    protected override PlatformView CreatePlatformView() => new(Context, VirtualView);
+    protected override PlatformView CreatePlatformView() 
+                                    => new(Context,
+                                            VirtualView,
+                                            IPlatformApplication.Current.Services.GetService<CameraService>());
 #elif IOS || MACCATALYST || WINDOWS
     protected override PlatformView CreatePlatformView() => new(VirtualView);
 #else

--- a/Camera.MAUI/Internals/ObservableBase.cs
+++ b/Camera.MAUI/Internals/ObservableBase.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Camera.MAUI.Internals;
+
+/// <summary>
+/// Provides base impl for supporting bindings via <see cref="System.ComponentModel.INotifyPropertyChanged"/>
+/// </summary>
+public abstract class ObservableBase : System.ComponentModel.INotifyPropertyChanged,
+                                       System.ComponentModel.INotifyPropertyChanging
+{
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+
+    /// <summary>
+    /// Call this from a property setter BEFORE setting the backing field,
+    /// calling <see cref="SetProperty{T}(ref T, T, string)"/>,
+    /// or calling <see cref="OnPropertyChanged(string)"/>
+    /// </summary>
+    /// <param name="propertyName"></param>
+    virtual protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+    }
+
+    virtual protected void OnPropertyChanging([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanging?.Invoke(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+    }
+
+    virtual protected bool SetProperty<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(backingField, value))
+            return false;
+
+        // call now, no performance hit if no event subscribers.
+        OnPropertyChanging(propertyName);
+
+        backingField = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    /// <summary>
+    /// Redirects to <see cref="SetProperty{T}(ref T, T, string)"/>, makes translating from bindable properties easier
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="backingField"></param>
+    /// <param name="value"></param>
+    /// <param name="propertyName"></param>
+    /// <returns></returns>
+    protected bool SetValue<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null) =>
+        SetProperty(ref backingField, value, propertyName);
+}

--- a/Camera.MAUI/Platforms/Android/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Android/MauiCameraView.cs
@@ -42,8 +42,6 @@ internal class MauiCameraView : GridLayout
     private CameraManager cameraManager;
     private AudioManager audioManager;
     private readonly System.Timers.Timer timer;
-    private readonly SparseIntArray ORIENTATIONS = new();
-    private readonly SparseIntArray ORIENTATIONSFRONT = new();
     private CameraCharacteristics camChars;
     private PreviewCaptureStateCallback sessionCallback;
     private byte[] capturePhoto = null;
@@ -52,9 +50,11 @@ internal class MauiCameraView : GridLayout
     private HandlerThread backgroundThread;
     private Handler backgroundHandler;
     private ImageReader imgReader;
+    private readonly CameraService _camService;
 
-
-    public MauiCameraView(Context context, CameraView cameraView) : base(context)
+    public MauiCameraView(Context context,
+                          CameraView cameraView,
+                          CameraService camService) : base(context)
     {
         this.context = context;
         this.cameraView = cameraView;
@@ -65,15 +65,8 @@ internal class MauiCameraView : GridLayout
         stateListener = new MyCameraStateCallback(this);
         photoListener = new ImageAvailableListener(this);
         AddView(textureView);
-        ORIENTATIONS.Append((int)SurfaceOrientation.Rotation0, 90);
-        ORIENTATIONS.Append((int)SurfaceOrientation.Rotation90, 0);
-        ORIENTATIONS.Append((int)SurfaceOrientation.Rotation180, 270);
-        ORIENTATIONS.Append((int)SurfaceOrientation.Rotation270, 180);
 
-        ORIENTATIONSFRONT.Append((int)SurfaceOrientation.Rotation0, 270);
-        ORIENTATIONSFRONT.Append((int)SurfaceOrientation.Rotation90, 0);
-        ORIENTATIONSFRONT.Append((int)SurfaceOrientation.Rotation180, 90);
-        ORIENTATIONSFRONT.Append((int)SurfaceOrientation.Rotation270, 180);
+        _camService = camService;
 
         InitDevices();
     }
@@ -142,6 +135,17 @@ internal class MauiCameraView : GridLayout
             //Microphone = Micros.FirstOrDefault();
             executorService = CameraExecutor;
 
+            _camService.StartAccelerometer();
+
+#if DEBUG
+            _camService.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(CameraService.DeviceOrientationAngle))
+                {
+                    CheckOrientation();
+                }
+            };
+#endif
             initiated = true;
             cameraView.RefreshDevices();
         }
@@ -216,22 +220,8 @@ internal class MauiCameraView : GridLayout
                             maxVideoSize = new((int)Resolution.Width, (int)Resolution.Height);
                         mediaRecorder.SetVideoSize(maxVideoSize.Width, maxVideoSize.Height);
 
-                        IWindowManager windowManager = context.GetSystemService(Context.WindowService).JavaCast<IWindowManager>();
-
-                        int rotation = (int)windowManager.DefaultDisplay.Rotation;
-                        int orientation = 0;
-
-                        // Set camera rotation based on front or back camera.
-                        if (cameraView.Camera.Position == CameraPosition.Back)
-                            orientation = ORIENTATIONS.Get(rotation);
-                        else
-                            orientation = ORIENTATIONSFRONT.Get(rotation);
-
-                        mediaRecorder.SetOrientationHint(orientation);
-
-                        Console.WriteLine($"Rotation: {rotation} Orientation: {orientation}");
-
-
+                        mediaRecorder.SetOrientationHint(CheckOrientation());
+                        _camService.StopAccelerometer(); // no need to burn battery while recording, we just got the state
                         mediaRecorder.Prepare();
 
                         if (OperatingSystem.IsAndroidVersionAtLeast(28))
@@ -242,8 +232,8 @@ internal class MauiCameraView : GridLayout
                     }
                     catch (Exception ex)
                     {
-                        Console.Write(ex.ToString());
-                        Console.Write(ex.StackTrace);
+                        DebugOut.Write(ex.ToString());
+                        DebugOut.Write(ex.StackTrace);
                         result = CameraResult.AccessError;
                     }
                 }
@@ -257,6 +247,30 @@ internal class MauiCameraView : GridLayout
             result = CameraResult.NotInitiated;
 
         return result;
+    }
+
+    // 0=landscape left, 90=portrait(up), 180=landscape right, 270=upside down (rear cam)
+    static readonly int[] degrees = { 0, 90, 180, 270 };
+
+    /// <summary>
+    /// We want to map the raw device orientation to the expected window orientation in case app-orientation is locked.
+    /// Uses accelerometer to determine device orientation in degrees (0 = landscape with "top"/camera-end of phone to user-left)
+    /// </summary>
+    /// <returns></returns>
+    private int CheckOrientation()
+    {
+        float angle = _camService.DeviceOrientationAngle;
+        // Map angle to nearest 0, 90, 180, 270 degrees
+        uint index = (uint)Math.Round(angle / 90.0f) % 4u;
+        int deviceOrientation = degrees[index];
+        deviceOrientation = cameraView?.Camera?.Position == CameraPosition.Front
+                            ? (360 - deviceOrientation) % 360 // adjust for front cam
+                            : deviceOrientation;
+
+        DebugOut.WriteLine($"Device orientation angle: {angle:F2}°, mapped: {deviceOrientation}°");
+
+        // Return the mapped degrees for use as orientation hint for camera when recording
+        return deviceOrientation;
     }
 
     private async void StartPreview()
@@ -375,6 +389,9 @@ internal class MauiCameraView : GridLayout
     internal Task<CameraResult> StopRecordingAsync()
     {
         recording = false;
+        // restart monitoring of orientation so it is available @ next record session.
+        // probably should move internal to StartCameraAsync?
+        _camService.StartAccelerometer();
         return StartCameraAsync(cameraView.PhotosResolution);
     }
 

--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,8 @@ source [repo](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_git
 github [mirror](https://github.com/jasells/CameraMaui) 
 
 [![Build status](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_apis/build/status/XDev.Maui.ManualCrop-CI-clone)](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_build/latest?definitionId=87)
+
+Forked from : https://github.com/janusw/CameraMaui
 ## CameraView
 
 A ContetView control for camera management with the next properties:

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,15 @@
 
 A Camera View control and a Barcode Endode/Decode control (based on ZXing.Net) for .NET MAUI applications.
 
+<div>Latest release <a href="https://www.nuget.org/packages/XDev.CameraMaui"> <img src="https://img.shields.io/nuget/v/XDev.CameraMaui"></a></div>
+
+<div>Latest build <a href="https://www.nuget.org/packages/XDev.CameraMaui"> <img src="https://img.shields.io/nuget/vpre/XDev.CameraMaui"></a></div>
+
+source [repo](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_git/XDev.Camera.Maui) 
+
+github [mirror](https://github.com/jasells/CameraMaui) 
+
+[![Build status](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_apis/build/status/XDev.Maui.ManualCrop-CI-clone)](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_build/latest?definitionId=87)
 ## CameraView
 
 A ContetView control for camera management with the next properties:

--- a/Readme.md
+++ b/Readme.md
@@ -11,8 +11,7 @@ source [repo](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_git
 
 github [mirror](https://github.com/jasells/CameraMaui) 
 
-[![Build status](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_apis/build/status/XDev.Maui.ManualCrop-CI-clone)](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_build/latest?definitionId=87)
-
+[![Build status](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_apis/build/status/XDev.CameraMaui-CI)](https://xdevapps.visualstudio.com/DefaultCollection/XDev.Maui/_build/latest?definitionId=86)
 Forked from : https://github.com/janusw/CameraMaui
 ## CameraView
 


### PR DESCRIPTION
Fixes #50 on Android by tracking _physical_ orientation of the device, not the window/app-layout default orientation.

Depends/based on #63.